### PR TITLE
Dismissing the initial progress dialog was disabled.

### DIFF
--- a/Android/CampusMovil/app/src/main/AndroidManifest.xml
+++ b/Android/CampusMovil/app/src/main/AndroidManifest.xml
@@ -68,20 +68,10 @@
             android:screenOrientation="portrait" >
         </activity>
         <activity
-            android:name="com.sicomeafit.campusmovil.SearchHandler"
-            android:label="@string/title_activity_search_handler" >
-            <intent-filter>
-                <action android:name="android.intent.action.SEARCH" />
-            </intent-filter>
-
-            <meta-data
-                android:name="android.app.searchable"
-                android:resource="@xml/searchable" />
-        </activity>
-        <activity
             android:name="com.sicomeafit.campusmovil.controllers.Places"
             android:label="@string/title_activity_places"
-            android:launchMode="singleTop" >
+            android:launchMode="singleTop"
+            android:screenOrientation="portrait" >
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH" />
             </intent-filter>
@@ -101,10 +91,6 @@
             android:screenOrientation="portrait" >
         </activity>
         <activity
-            android:name="com.sicomeafit.campusmovil.Adapters"
-            android:label="@string/title_activity_adapters" >
-        </activity>
-        <activity
             android:name="com.sicomeafit.campusmovil.controllers.MapAccess"
             android:label="@string/title_activity_map_access"
             android:screenOrientation="portrait" >
@@ -112,7 +98,8 @@
         <activity
             android:name="com.sicomeafit.campusmovil.controllers.UserMarkersManager"
             android:label="@string/title_activity_user_markers_manager"
-            android:launchMode="singleTop" >
+            android:launchMode="singleTop"
+            android:screenOrientation="portrait" >
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH" />
             </intent-filter>
@@ -124,7 +111,8 @@
         <activity
             android:name="com.sicomeafit.campusmovil.controllers.UserMarkers"
             android:label="@string/my_markers"
-            android:launchMode="singleTop" >
+            android:launchMode="singleTop"
+            android:screenOrientation="portrait" >
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH" />
             </intent-filter>
@@ -135,7 +123,8 @@
         </activity>
         <activity
             android:name="com.sicomeafit.campusmovil.controllers.UserNotes"
-            android:label="@string/title_activity_user_notes" >
+            android:label="@string/title_activity_user_notes"
+            android:screenOrientation="portrait" >
         </activity>
     </application>
 

--- a/Android/CampusMovil/app/src/main/java/com/sicomeafit/campusmovil/helpers/HttpHandler.java
+++ b/Android/CampusMovil/app/src/main/java/com/sicomeafit/campusmovil/helpers/HttpHandler.java
@@ -52,8 +52,8 @@ public class HttpHandler {
     public static final String SERVER_INTERNAL_ERROR_STRING = "server_internal_error";
 
     //Dominio del servidor.
-    private static final String DOMAIN = "http://campusmovilapp.herokuapp.com/";//"http://104.236.191.184/";
-    public static final String API_V1 = "api/v1";
+    private static final String DOMAIN = "http://campusmovilapp.herokuapp.com";//"http://104.236.191.184/";
+    public static final String API_V1 = "/api/v1";
 
     private SubscribedActivities listeningActivity;
 
@@ -321,7 +321,7 @@ public class HttpHandler {
                     progressDialog.setMessage(context.getString(R.string.saving_note));
                     break;
             }
-
+            progressDialog.setCanceledOnTouchOutside(false);
             progressDialog.show();
         }
 


### PR DESCRIPTION
The app was stopping when the map markers couldn't be fully load. Thus, dismissing the progress dialog was disabled to avoid user's outside click.
